### PR TITLE
Add support for Rails 5.0 to 6.1 load_defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,14 @@ claude "The app is on Rails 7.2 but load_defaults is at 6.1, let's upgrade"
 
 | Transition | Config Reference  | Template                                  |
 | ---------- | ----------------- | ----------------------------------------- |
+| → 5.0      | `configs/5_0.yml` | `templates/new_framework_defaults_5_0.rb` |
+| → 5.1      | `configs/5_1.yml` | `templates/new_framework_defaults_5_1.rb` |
+| → 5.2      | `configs/5_2.yml` | `templates/new_framework_defaults_5_2.rb` |
+| → 6.0      | `configs/6_0.yml` | `templates/new_framework_defaults_6_0.rb` |
+| → 6.1      | `configs/6_1.yml` | `templates/new_framework_defaults_6_1.rb` |
 | → 7.0      | `configs/7_0.yml` | `templates/new_framework_defaults_7_0.rb` |
+| → 7.1      | `configs/7_1.yml` | `templates/new_framework_defaults_7_1.rb` |
+| → 7.2      | `configs/7_2.yml` | `templates/new_framework_defaults_7_2.rb` |
 
 ## How It Works
 
@@ -105,18 +112,32 @@ config.action_view.button_to_generates_button_tag = false
 rails-load-defaults/
 ├── SKILL.md                                # Workflow instructions
 ├── configs/
-│   ├── 7_0.yml                             # Config reference with lookup logic
+│   ├── 5_0.yml                             # Config reference with lookup logic
+│   ├── 5_1.yml
+│   ├── 5_2.yml
+│   ├── 6_0.yml
+│   ├── 6_1.yml
+│   ├── 7_0.yml
+│   ├── 7_1.yml
+│   └── 7_2.yml
 └── templates/
-    ├── new_framework_defaults_7_0.rb       # Rails initializer
+    ├── new_framework_defaults_5_0.rb       # Rails initializer templates
+    ├── new_framework_defaults_5_1.rb
+    ├── new_framework_defaults_5_2.rb
+    ├── new_framework_defaults_6_0.rb
+    ├── new_framework_defaults_6_1.rb
+    ├── new_framework_defaults_7_0.rb
+    ├── new_framework_defaults_7_1.rb
+    ├── new_framework_defaults_7_2.rb
     └── cookie_rotator.rb                   # SHA1→SHA256 cookie rotation
 ```
 
 ## Adding New Versions
 
-To add support for a new Rails version (e.g., 7.2):
+To add support for a new Rails version (e.g., 8.0):
 
-1. Add `templates/new_framework_defaults_7_2.rb` — the initializer from Rails
-2. Add `configs/7_2.yml` — config entries with tiers, lookup patterns, and decision trees
+1. Add `templates/new_framework_defaults_8_0.rb` — the initializer from Rails
+2. Add `configs/8_0.yml` — config entries with tiers, lookup patterns, and decision trees
 3. Update the version references in `SKILL.md`
 
 The workflow logic in `SKILL.md` is version-agnostic, so no other changes are needed.

--- a/SKILL.md
+++ b/SKILL.md
@@ -48,6 +48,11 @@ Report to the user:
 
 Read the appropriate config reference file for the target version:
 
+- **5.0**: `configs/5_0.yml`
+- **5.1**: `configs/5_1.yml`
+- **5.2**: `configs/5_2.yml`
+- **6.0**: `configs/6_0.yml`
+- **6.1**: `configs/6_1.yml`
 - **7.0**: `configs/7_0.yml`
 - **7.1**: `configs/7_1.yml`
 - **7.2**: `configs/7_2.yml`
@@ -60,6 +65,11 @@ and decision trees for each config.
 If no `new_framework_defaults_X_Y.rb` exists yet, copy the template from
 the `templates/` directory into the app's `config/initializers/`:
 
+- **5.0**: Copy `templates/new_framework_defaults_5_0.rb` → `config/initializers/new_framework_defaults_5_0.rb`
+- **5.1**: Copy `templates/new_framework_defaults_5_1.rb` → `config/initializers/new_framework_defaults_5_1.rb`
+- **5.2**: Copy `templates/new_framework_defaults_5_2.rb` → `config/initializers/new_framework_defaults_5_2.rb`
+- **6.0**: Copy `templates/new_framework_defaults_6_0.rb` → `config/initializers/new_framework_defaults_6_0.rb`
+- **6.1**: Copy `templates/new_framework_defaults_6_1.rb` → `config/initializers/new_framework_defaults_6_1.rb`
 - **7.0**: Copy `templates/new_framework_defaults_7_0.rb` → `config/initializers/new_framework_defaults_7_0.rb`
 - **7.1**: Copy `templates/new_framework_defaults_7_1.rb` → `config/initializers/new_framework_defaults_7_1.rb`
 - **7.2**: Copy `templates/new_framework_defaults_7_2.rb` → `config/initializers/new_framework_defaults_7_2.rb`

--- a/configs/5_0.yml
+++ b/configs/5_0.yml
@@ -1,0 +1,154 @@
+# Rails 5.0 Framework Defaults Config Reference
+#
+# Configs are organized into tiers:
+#   tier_1: Safe to flip — test-only or trivially low risk
+#   tier_2: Low risk — need a quick codebase grep to confirm
+#   tier_3: Medium/high risk — need careful analysis (future addition)
+#
+# Processing order: tier_1 first, then tier_2, then tier_3.
+#
+# NOTE: The 5.0 new_framework_defaults file uses a different format than later
+# versions. Configs are listed with the OLD value (not commented out), and you
+# need to FLIP them to the new value. The template preserves this original format.
+
+version: "5.0"
+
+tier_1:
+  # ---- Test-only or trivially safe configs ----
+
+  - config: action_controller.raise_on_unfiltered_parameters
+    config_line: "Rails.application.config.action_controller.raise_on_unfiltered_parameters = true"
+    new_default: true
+    old_default: false
+    risk: very_low
+    old_behavior: "Shows a deprecation warning when unfiltered parameters are used"
+    new_behavior: >
+      Raises an error when unfiltered parameters are used. This setting was
+      deprecated in Rails 5.1 (always behaves as true) and removed in 5.2.
+    lookup: []
+    decision: >
+      Always safe to use new default (true). This setting helps surface
+      deprecation issues. It was removed in Rails 5.2, so it only matters
+      during the 5.0 to 5.1 transition. After all deprecation warnings are
+      fixed, flip to true. Remove this setting entirely when upgrading to 5.2.
+
+  - config: active_support.halt_callback_chains_on_return_false
+    config_line: "ActiveSupport.halt_callback_chains_on_return_false = false"
+    new_default: false
+    old_default: true
+    risk: very_low
+    old_behavior: "Callback chains are halted when a callback returns false"
+    new_behavior: >
+      Callback chains are NOT halted when a callback returns false. Only
+      `throw :abort` halts the chain. This avoids accidental halting when
+      a callback happens to return false.
+    lookup:
+      - search: "return false"
+        in: "app/models/**/*.rb, app/controllers/**/*.rb"
+        reason: "Check for callbacks that explicitly return false to halt the chain"
+    decision: >
+      If no callbacks explicitly return false to halt execution → safe to use
+      new default (false).
+      If callbacks return false intentionally to halt → change them to use
+      `throw :abort` instead, then flip to false.
+      This is a well-documented Rails 5.0 change. Most apps should already be
+      using throw :abort if they upgraded to 5.0.
+
+tier_2:
+  # ---- Low risk configs needing a codebase check ----
+
+  - config: action_controller.per_form_csrf_tokens
+    config_line: "Rails.application.config.action_controller.per_form_csrf_tokens = true"
+    new_default: true
+    old_default: false
+    risk: low
+    old_behavior: "A single CSRF token is used across all forms"
+    new_behavior: "Each form gets its own CSRF token for improved security"
+    lookup:
+      - search: "csrf"
+        in: "config/**/*.rb, app/controllers/**/*.rb"
+        reason: "Check for any custom CSRF handling"
+      - search: "verify_authenticity_token"
+        in: "app/controllers/**/*.rb"
+        reason: "Check for custom authenticity token verification"
+    decision: >
+      If no custom CSRF handling → safe to use new default (true). This is a
+      security improvement.
+      If custom CSRF handling exists → review to ensure per-form tokens are
+      compatible. In most cases they are.
+      Most apps → safe to use new default.
+
+  - config: action_controller.forgery_protection_origin_check
+    config_line: "Rails.application.config.action_controller.forgery_protection_origin_check = true"
+    new_default: true
+    old_default: false
+    risk: low
+    old_behavior: "CSRF protection does not check the HTTP Origin header"
+    new_behavior: "CSRF protection also verifies the HTTP Origin header matches"
+    lookup:
+      - search: "forgery_protection\\|csrf"
+        in: "config/**/*.rb, app/controllers/**/*.rb"
+        reason: "Check for custom forgery protection settings"
+      - search: "protect_from_forgery"
+        in: "app/controllers/**/*.rb"
+        reason: "Check for custom forgery protection configuration"
+    decision: >
+      If no custom forgery protection config → safe to use new default (true).
+      This is a security improvement.
+      If the app receives cross-origin requests that should be allowed →
+      review the origin checking behavior to ensure it won't block legitimate
+      requests.
+      Most apps → safe to use new default.
+
+  - config: active_support.to_time_preserves_timezone
+    config_line: "ActiveSupport.to_time_preserves_timezone = true"
+    new_default: true
+    old_default: false
+    risk: low
+    old_behavior: "to_time converts to local system timezone"
+    new_behavior: "to_time preserves the timezone of the receiver"
+    lookup:
+      - search: "\\.to_time"
+        in: "app/**/*.rb, lib/**/*.rb"
+        reason: "Check for usage of to_time method"
+    decision: >
+      If no to_time usage found → safe to use new default (true), zero impact.
+      If to_time is used → the new behavior is generally more correct (preserves
+      timezone). Check if any code depends on to_time returning local time.
+      Most apps → safe to use new default.
+
+  - config: active_record.belongs_to_required_by_default
+    config_line: "Rails.application.config.active_record.belongs_to_required_by_default = true"
+    new_default: true
+    old_default: false
+    risk: low
+    old_behavior: "belongs_to associations allow nil by default"
+    new_behavior: "belongs_to associations are required (not nil) by default"
+    lookup:
+      - search: "belongs_to"
+        in: "app/models/**/*.rb"
+        reason: "Find all belongs_to associations"
+      - search: "optional: true"
+        in: "app/models/**/*.rb"
+        reason: "Check which associations already declare optional: true"
+    decision: >
+      If no belongs_to associations → safe to use new default (true).
+      If belongs_to associations exist → check if any intentionally allow nil.
+      Those need `optional: true` added before flipping this.
+      Run the test suite — validation errors will clearly surface any issues.
+      This is a well-known Rails 5.0 change most apps handle during upgrade.
+
+# ---- Tier 3: Higher risk configs (documented but NOT auto-processed) ----
+
+tier_3_reference:
+  - config: ssl_options
+    config_line: "config.ssl_options = { hsts: { subdomains: true } }"
+    new_default: "{ hsts: { subdomains: true } }"
+    old_default: "{}"
+    risk: medium
+    note: >
+      This is set by load_defaults 5.0 but is NOT in the new_framework_defaults
+      file. It enables HSTS subdomains by default. Only relevant if the app uses
+      force_ssl. If subdomains don't support HTTPS, this can cause issues. Check
+      if force_ssl is enabled and whether all subdomains support HTTPS before
+      enabling.

--- a/configs/5_1.yml
+++ b/configs/5_1.yml
@@ -1,0 +1,69 @@
+# Rails 5.1 Framework Defaults Config Reference
+#
+# Configs are organized into tiers:
+#   tier_1: Safe to flip — test-only or trivially low risk
+#   tier_2: Low risk — need a quick codebase grep to confirm
+#   tier_3: Medium/high risk — need careful analysis
+#
+# Processing order: tier_1 first, then tier_2, then tier_3.
+
+version: "5.1"
+
+tier_1:
+  # ---- Test-only or trivially safe configs ----
+  []
+
+tier_2:
+  # ---- Low risk configs needing a codebase check ----
+
+  - config: action_view.form_with_generates_remote_forms
+    config_line: "Rails.application.config.action_view.form_with_generates_remote_forms = true"
+    new_default: true
+    old_default: false
+    risk: low
+    old_behavior: "form_with generates non-remote (standard) forms"
+    new_behavior: >
+      form_with generates remote (AJAX) forms by default. Note: this default
+      changes BACK to false in Rails 6.1. If removing this file in favor of
+      load_defaults, recommend setting the value explicitly to prevent defaults
+      from changing it in future versions.
+    lookup:
+      - search: "form_with"
+        in: "app/views/**/*.erb, app/views/**/*.haml, app/views/**/*.slim"
+        reason: "Find all usages of form_with helper"
+      - search: "remote:"
+        in: "app/views/**/*.erb, app/views/**/*.haml, app/views/**/*.slim"
+        reason: "Check if forms already specify remote: option explicitly"
+      - search: "turbolinks\\|rails-ujs\\|@rails/ujs"
+        in: "Gemfile, app/javascript/**/*.js, app/assets/javascripts/**/*.js"
+        reason: "Check if the app has UJS/Turbolinks for handling remote forms"
+    decision: >
+      If form_with is not used → safe to use new default (true), zero impact.
+      If form_with is used and app has rails-ujs/Turbolinks → safe, remote forms
+      will work as expected.
+      If form_with is used but no UJS → keep false, remote forms won't work
+      without JavaScript handling.
+      IMPORTANT: This default flips back to false in 6.1. Consider setting the
+      value explicitly regardless of which default you choose.
+
+  - config: assets.unknown_asset_fallback
+    config_line: "Rails.application.config.assets.unknown_asset_fallback = false"
+    new_default: false
+    old_default: true
+    risk: low
+    old_behavior: "Unknown asset paths are passed through as-is (fallback to path)"
+    new_behavior: "Unknown asset paths raise an error in the asset pipeline"
+    lookup:
+      - search: "asset_path\\|image_tag\\|javascript_include_tag\\|stylesheet_link_tag"
+        in: "app/views/**/*.erb, app/views/**/*.haml, app/views/**/*.slim"
+        reason: "Check for asset helper usage that might reference non-pipeline assets"
+      - search: "config.assets"
+        in: "config/**/*.rb"
+        reason: "Check for existing asset pipeline configuration"
+    decision: >
+      If the app uses the asset pipeline properly → safe to use new default (false).
+      If the app references assets outside the pipeline by path → keep true to
+      avoid errors, or fix the asset references.
+      Most apps → safe to use new default.
+
+tier_3_reference: []

--- a/configs/5_1.yml
+++ b/configs/5_1.yml
@@ -9,10 +9,8 @@
 
 version: "5.1"
 
-tier_1:
+tier_1: []
   # ---- Test-only or trivially safe configs ----
-  []
-
 tier_2:
   # ---- Low risk configs needing a codebase check ----
 

--- a/configs/5_2.yml
+++ b/configs/5_2.yml
@@ -1,0 +1,132 @@
+# Rails 5.2 Framework Defaults Config Reference
+#
+# Configs are organized into tiers:
+#   tier_1: Safe to flip — test-only or trivially low risk
+#   tier_2: Low risk — need a quick codebase grep to confirm
+#   tier_3: Medium/high risk — need careful analysis
+#
+# Processing order: tier_1 first, then tier_2, then tier_3.
+
+version: "5.2"
+
+tier_1:
+  # ---- Test-only or trivially safe configs ----
+
+  - config: action_view.form_with_generates_ids
+    config_line: "Rails.application.config.action_view.form_with_generates_ids = true"
+    new_default: true
+    old_default: false
+    risk: very_low
+    old_behavior: "form_with does not generate id attributes on HTML tags"
+    new_behavior: "form_with generates id attributes for any generated HTML tags"
+    lookup: []
+    decision: >
+      Always safe to use new default (true). Adding id attributes to form
+      elements is purely additive and does not break existing functionality.
+      It makes forms more accessible and easier to target with CSS/JS.
+
+  - config: action_controller.default_protect_from_forgery
+    config_line: "Rails.application.config.action_controller.default_protect_from_forgery = true"
+    new_default: true
+    old_default: false
+    risk: very_low
+    old_behavior: "Forgery protection must be added explicitly in ApplicationController"
+    new_behavior: "ActionController::Base includes forgery protection by default"
+    lookup:
+      - search: "protect_from_forgery"
+        in: "app/controllers/application_controller.rb"
+        reason: "Check if ApplicationController already has protect_from_forgery"
+    decision: >
+      If ApplicationController already has protect_from_forgery → safe to use
+      new default (true), it's redundant but harmless.
+      If ApplicationController does NOT have protect_from_forgery → this adds
+      it. Should be safe for most apps as CSRF protection is standard practice.
+      Most apps → safe to use new default.
+
+tier_2:
+  # ---- Low risk configs needing a codebase check ----
+
+  - config: active_record.cache_versioning
+    config_line: "Rails.application.config.active_record.cache_versioning = true"
+    new_default: true
+    old_default: false
+    risk: low
+    old_behavior: "Cache key includes the updated_at timestamp directly"
+    new_behavior: >
+      Cache key is stable, and a separate cache_version holds the volatile
+      timestamp. This enables recyclable cache keys.
+    lookup:
+      - search: "cache_key"
+        in: "app/**/*.rb, lib/**/*.rb"
+        reason: "Check for direct use of cache_key method"
+      - search: "Rails.cache"
+        in: "app/**/*.rb, lib/**/*.rb"
+        reason: "Check for cache usage in the app"
+    decision: >
+      If no caching is used → safe to use new default (true), zero impact.
+      If caching is used → the new default is generally better (recyclable keys).
+      Check if any code parses or depends on the format of cache_key.
+      Most apps → safe to use new default.
+
+  - config: active_support.use_authenticated_message_encryption
+    config_line: "Rails.application.config.active_support.use_authenticated_message_encryption = true"
+    new_default: true
+    old_default: false
+    risk: low
+    old_behavior: "Messages are encrypted with AES-256-CBC"
+    new_behavior: "Messages are encrypted with AES-256-GCM (authenticated encryption)"
+    lookup:
+      - search: "MessageEncryptor\\|encrypt_and_sign\\|decrypt_and_verify"
+        in: "app/**/*.rb, lib/**/*.rb"
+        reason: "Check for direct use of message encryption"
+    decision: >
+      If no direct message encryption usage → safe to use new default (true).
+      If message encryption is used → new messages will use GCM. Old CBC
+      messages can still be read. Only concern is if external systems read
+      these encrypted messages and expect CBC format.
+      Most apps → safe to use new default.
+
+  - config: active_support.use_sha1_digests
+    config_line: "Rails.application.config.active_support.use_sha1_digests = true"
+    new_default: true
+    old_default: false
+    risk: low
+    old_behavior: "Non-sensitive digests (ETags, etc.) use MD5"
+    new_behavior: >
+      Non-sensitive digests use SHA-1. Note: this default changes back in
+      Rails 7.0 where it switches to SHA-256. If removing this file in favor
+      of load_defaults, recommend setting the value explicitly to prevent
+      defaults from changing it.
+    lookup:
+      - search: "etag\\|ETag\\|stale?"
+        in: "app/controllers/**/*.rb"
+        reason: "Check for ETag usage"
+    decision: >
+      If no explicit ETag/digest usage → safe to use new default (true).
+      Changing the digest algorithm will invalidate ETags and similar caches,
+      causing a one-time cache miss.
+      IMPORTANT: This default changes again in 7.0 (to SHA-256). Consider
+      whether to set this explicitly.
+      Most apps → safe to use new default.
+
+tier_3_reference:
+  - config: action_dispatch.use_authenticated_cookie_encryption
+    config_line: "Rails.application.config.action_dispatch.use_authenticated_cookie_encryption = true"
+    new_default: true
+    old_default: false
+    risk: high
+    note: >
+      Switches cookie encryption to AES-256-GCM and embeds expiry metadata.
+      Not backwards compatible with earlier Rails versions. Existing cookies
+      are converted on read and rewritten with the new scheme. Only enable
+      after the app is fully stable on 5.2 with no rollback plans.
+
+  - config: active_record.sqlite3.represent_boolean_as_integer
+    config_line: "Rails.application.config.active_record.sqlite3.represent_boolean_as_integer = true"
+    new_default: true
+    old_default: false
+    risk: medium
+    note: >
+      Stores booleans as 1/0 instead of 't'/'f' in SQLite3. Only relevant
+      if the app uses SQLite. Requires a data migration for existing boolean
+      columns. If using PostgreSQL or MySQL, this has no impact.

--- a/configs/6_0.yml
+++ b/configs/6_0.yml
@@ -1,0 +1,166 @@
+# Rails 6.0 Framework Defaults Config Reference
+#
+# Configs are organized into tiers:
+#   tier_1: Safe to flip — test-only or trivially low risk
+#   tier_2: Low risk — need a quick codebase grep to confirm
+#   tier_3: Medium/high risk — need careful analysis
+#
+# Processing order: tier_1 first, then tier_2, then tier_3.
+
+version: "6.0"
+
+tier_1:
+  # ---- Test-only or trivially safe configs ----
+
+  - config: action_view.default_enforce_utf8
+    config_line: "Rails.application.config.action_view.default_enforce_utf8 = false"
+    new_default: false
+    old_default: true
+    risk: very_low
+    old_behavior: "Forms include a hidden UTF-8 enforcement field for old IE browsers"
+    new_behavior: "Forms no longer include the hidden UTF-8 enforcement field"
+    lookup: []
+    decision: >
+      Always safe to use new default (false). The UTF-8 enforcement was only
+      needed for old versions of IE that are no longer supported. Removing it
+      slightly reduces form payload size.
+
+tier_2:
+  # ---- Low risk configs needing a codebase check ----
+
+  - config: action_dispatch.return_only_media_type_on_content_type
+    config_line: "Rails.application.config.action_dispatch.return_only_media_type_on_content_type = false"
+    new_default: false
+    old_default: true
+    risk: low
+    old_behavior: "ActionDispatch::Response#content_type returns only the MIME type (e.g., 'text/html')"
+    new_behavior: >
+      content_type returns the full Content-Type header including charset
+      (e.g., 'text/html; charset=utf-8'). This setting is deprecated in
+      Rails 6.1 and removed in 7.0 where the final behavior matches false.
+    lookup:
+      - search: "content_type"
+        in: "app/controllers/**/*.rb, spec/**/*.rb, test/**/*.rb"
+        reason: "Check for code that reads response.content_type and may depend on format"
+    decision: >
+      If no code checks response.content_type → safe to use new default (false).
+      If tests compare content_type to a string like "text/html" → they may
+      need updating to include charset.
+      This is deprecated in 6.1 and removed in 7.0 anyway.
+      Most apps → safe to use new default.
+
+  - config: active_job.return_false_on_aborted_enqueue
+    config_line: "Rails.application.config.active_job.return_false_on_aborted_enqueue = true"
+    new_default: true
+    old_default: false
+    risk: low
+    old_behavior: "Aborted enqueue returns the job instance (self)"
+    new_behavior: >
+      Aborted enqueue returns false. This setting is deprecated in Rails 6.1
+      and removed in 7.0 where the final behavior matches true.
+    lookup:
+      - search: "perform_later\\|enqueue"
+        in: "app/**/*.rb, lib/**/*.rb"
+        reason: "Check for code that checks the return value of enqueue/perform_later"
+      - search: "before_enqueue\\|around_enqueue"
+        in: "app/jobs/**/*.rb"
+        reason: "Check for enqueue callbacks that might abort"
+    decision: >
+      If no code checks the return value of perform_later/enqueue → safe.
+      If code checks the return value → update to handle false instead of self.
+      This is deprecated in 6.1 and removed in 7.0 anyway.
+      Most apps → safe to use new default.
+
+  - config: active_storage.queues.analysis
+    config_line: "Rails.application.config.active_storage.queues.analysis = :active_storage_analysis"
+    new_default: ":active_storage_analysis"
+    old_default: "nil (default queue)"
+    risk: low
+    old_behavior: "Active Storage analysis jobs go to the default queue"
+    new_behavior: >
+      Analysis jobs go to a dedicated :active_storage_analysis queue.
+      Note: this is later changed to nil in Rails 6.1 defaults.
+    lookup:
+      - search: "has_one_attached\\|has_many_attached"
+        in: "app/models/**/*.rb"
+        reason: "Check if Active Storage is used"
+      - search: "active_storage_analysis"
+        in: "config/**/*.rb"
+        reason: "Check if queue is already configured"
+    decision: >
+      If Active Storage is not used → no impact, safe to use new default.
+      If Active Storage is used → ensure the queue adapter processes the
+      :active_storage_analysis queue. Note this changes to nil in 6.1.
+      Most apps → safe to use new default.
+
+  - config: active_storage.queues.purge
+    config_line: "Rails.application.config.active_storage.queues.purge = :active_storage_purge"
+    new_default: ":active_storage_purge"
+    old_default: "nil (default queue)"
+    risk: low
+    old_behavior: "Active Storage purge jobs go to the default queue"
+    new_behavior: >
+      Purge jobs go to a dedicated :active_storage_purge queue.
+      Note: this is later changed to nil in Rails 6.1 defaults.
+    lookup:
+      - search: "has_one_attached\\|has_many_attached"
+        in: "app/models/**/*.rb"
+        reason: "Check if Active Storage is used"
+      - search: "active_storage_purge"
+        in: "config/**/*.rb"
+        reason: "Check if queue is already configured"
+    decision: >
+      If Active Storage is not used → no impact, safe to use new default.
+      If Active Storage is used → ensure the queue adapter processes the
+      :active_storage_purge queue. Note this changes to nil in 6.1.
+      Most apps → safe to use new default.
+
+  - config: active_record.collection_cache_versioning
+    config_line: "Rails.application.config.active_record.collection_cache_versioning = true"
+    new_default: true
+    old_default: false
+    risk: low
+    old_behavior: "Relation cache keys include volatile info (max updated_at, count)"
+    new_behavior: >
+      Volatile info moves to cache_version, enabling recyclable cache keys
+      for ActiveRecord::Relation objects.
+    lookup:
+      - search: "cache_key\\|cache"
+        in: "app/**/*.rb"
+        reason: "Check for caching of ActiveRecord relations"
+    decision: >
+      If no relation caching → safe to use new default (true), zero impact.
+      If caching is used → new default is generally better. Check if any code
+      depends on the format of relation cache keys.
+      Most apps → safe to use new default.
+
+tier_3_reference:
+  - config: action_dispatch.use_cookies_with_metadata
+    config_line: "Rails.application.config.action_dispatch.use_cookies_with_metadata = true"
+    new_default: true
+    old_default: false
+    risk: high
+    note: >
+      Embeds purpose and expiry metadata in signed/encrypted cookies. Not
+      backwards compatible with earlier Rails versions. Only enable after
+      the app is fully stable on 6.0 with no rollback plans.
+
+  - config: active_storage.replace_on_assign_to_many
+    config_line: "Rails.application.config.active_storage.replace_on_assign_to_many = true"
+    new_default: true
+    old_default: false
+    risk: medium
+    note: >
+      When assigning to has_many_attached, replaces existing attachments
+      instead of appending. Check all has_many_attached assignments to
+      ensure replace behavior is desired. Use #attach to append.
+
+  - config: action_mailer.delivery_job
+    config_line: 'Rails.application.config.action_mailer.delivery_job = "ActionMailer::MailDeliveryJob"'
+    new_default: '"ActionMailer::MailDeliveryJob"'
+    old_default: '"ActionMailer::DeliveryJob"'
+    risk: medium
+    note: >
+      Switches to the unified MailDeliveryJob. The old delivery jobs are
+      removed in Rails 6.1. Not backwards compatible — job workers need
+      MailDeliveryJob available. Ensure all workers are on 6.0 before enabling.

--- a/configs/6_1.yml
+++ b/configs/6_1.yml
@@ -1,0 +1,300 @@
+# Rails 6.1 Framework Defaults Config Reference
+#
+# Configs are organized into tiers:
+#   tier_1: Safe to flip — test-only or trivially low risk
+#   tier_2: Low risk — need a quick codebase grep to confirm
+#   tier_3: Medium/high risk — need careful analysis
+#
+# Processing order: tier_1 first, then tier_2, then tier_3.
+
+version: "6.1"
+
+tier_1:
+  # ---- Test-only or trivially safe configs ----
+
+  - config: active_job.retry_jitter
+    config_line: "Rails.application.config.active_job.retry_jitter = 0.15"
+    new_default: 0.15
+    old_default: 0.0
+    risk: very_low
+    old_behavior: "Retried jobs have no random jitter in their delay"
+    new_behavior: >
+      Retried jobs have up to 15% random variation in their retry delay.
+      This prevents thundering herd problems when many jobs fail and retry
+      at the same time.
+    lookup: []
+    decision: >
+      Always safe to use new default (0.15). This is a best practice that
+      prevents retry storms. No code changes needed.
+
+  - config: active_storage.queues.analysis
+    config_line: "Rails.application.config.active_storage.queues.analysis = nil"
+    new_default: nil
+    old_default: ":active_storage_analysis"
+    risk: very_low
+    old_behavior: "Analysis jobs go to a dedicated :active_storage_analysis queue"
+    new_behavior: "Analysis jobs go to the queue adapter default queue"
+    lookup:
+      - search: "has_one_attached\\|has_many_attached"
+        in: "app/models/**/*.rb"
+        reason: "Check if Active Storage is used"
+    decision: >
+      If Active Storage is not used → no impact, safe.
+      If Active Storage is used → safe to use new default (nil). Jobs go to
+      the default queue, which is simpler to manage.
+
+  - config: active_storage.queues.purge
+    config_line: "Rails.application.config.active_storage.queues.purge = nil"
+    new_default: nil
+    old_default: ":active_storage_purge"
+    risk: very_low
+    old_behavior: "Purge jobs go to a dedicated :active_storage_purge queue"
+    new_behavior: "Purge jobs go to the queue adapter default queue"
+    lookup:
+      - search: "has_one_attached\\|has_many_attached"
+        in: "app/models/**/*.rb"
+        reason: "Check if Active Storage is used"
+    decision: >
+      If Active Storage is not used → no impact, safe.
+      If Active Storage is used → safe to use new default (nil).
+
+  - config: action_mailbox.queues.incineration
+    config_line: "Rails.application.config.action_mailbox.queues.incineration = nil"
+    new_default: nil
+    old_default: ":action_mailbox_incineration"
+    risk: very_low
+    old_behavior: "Incineration jobs go to a dedicated queue"
+    new_behavior: "Incineration jobs go to the default queue"
+    lookup:
+      - search: "action_mailbox\\|ActionMailbox"
+        in: "app/**/*.rb, config/**/*.rb, Gemfile"
+        reason: "Check if Action Mailbox is used"
+    decision: >
+      If Action Mailbox is not used → no impact, safe.
+      If used → safe to use new default (nil).
+
+  - config: action_mailbox.queues.routing
+    config_line: "Rails.application.config.action_mailbox.queues.routing = nil"
+    new_default: nil
+    old_default: ":action_mailbox_routing"
+    risk: very_low
+    old_behavior: "Routing jobs go to a dedicated queue"
+    new_behavior: "Routing jobs go to the default queue"
+    lookup:
+      - search: "action_mailbox\\|ActionMailbox"
+        in: "app/**/*.rb, config/**/*.rb, Gemfile"
+        reason: "Check if Action Mailbox is used"
+    decision: >
+      If Action Mailbox is not used → no impact, safe.
+      If used → safe to use new default (nil).
+
+  - config: action_mailer.deliver_later_queue_name
+    config_line: "Rails.application.config.action_mailer.deliver_later_queue_name = nil"
+    new_default: nil
+    old_default: ":mailers"
+    risk: very_low
+    old_behavior: "Mail delivery jobs go to the :mailers queue"
+    new_behavior: "Mail delivery jobs go to the default queue"
+    lookup:
+      - search: "deliver_later"
+        in: "app/**/*.rb"
+        reason: "Check if deliver_later is used"
+      - search: "deliver_later_queue_name"
+        in: "config/**/*.rb"
+        reason: "Check if already customized"
+    decision: >
+      If deliver_later is not used → no impact, safe.
+      If used → safe to use new default (nil). Jobs go to the default queue.
+      If you have a specific queue setup for :mailers → keep the old value
+      or adjust your queue configuration.
+
+tier_2:
+  # ---- Low risk configs needing a codebase check ----
+
+  - config: active_record.has_many_inversing
+    config_line: "Rails.application.config.active_record.has_many_inversing = true"
+    new_default: true
+    old_default: false
+    risk: low
+    old_behavior: "belongs_to → has_many inverse is not automatic"
+    new_behavior: "Supports inversing belongs_to → has_many associations automatically"
+    lookup:
+      - search: "has_many.*inverse_of"
+        in: "app/models/**/*.rb"
+        reason: "Check for explicit inverse_of on has_many associations"
+    decision: >
+      If no explicit inverse_of on has_many → safe to use new default (true).
+      If explicit inverse_of exists → still safe, the explicit setting takes
+      precedence.
+      Most apps → safe to use new default.
+
+  - config: active_storage.track_variants
+    config_line: "Rails.application.config.active_storage.track_variants = true"
+    new_default: true
+    old_default: false
+    risk: low
+    old_behavior: "Active Storage variants are not tracked in the database"
+    new_behavior: "Variants are tracked in the database for better performance"
+    lookup:
+      - search: "has_one_attached\\|has_many_attached"
+        in: "app/models/**/*.rb"
+        reason: "Check if Active Storage is used"
+      - search: "variant"
+        in: "app/**/*.rb"
+        reason: "Check for variant usage"
+    decision: >
+      If Active Storage is not used → no impact, safe.
+      If variants are used → safe to enable. Requires the
+      active_storage_variant_records migration. Check if it exists.
+      If using Active Storage without variants → safe to enable.
+
+  - config: active_job.skip_after_callbacks_if_terminated
+    config_line: "Rails.application.config.active_job.skip_after_callbacks_if_terminated = true"
+    new_default: true
+    old_default: false
+    risk: low
+    old_behavior: "after_enqueue/after_perform run even if before callbacks halt with throw :abort"
+    new_behavior: >
+      after callbacks are skipped if before callbacks halt. Deprecated in 7.0,
+      final behavior is always true.
+    lookup:
+      - search: "after_enqueue\\|after_perform"
+        in: "app/jobs/**/*.rb"
+        reason: "Check for after callbacks in jobs"
+      - search: "before_enqueue\\|before_perform"
+        in: "app/jobs/**/*.rb"
+        reason: "Check for before callbacks that might abort"
+    decision: >
+      If no job callbacks → safe to use new default (true), zero impact.
+      If jobs have both before and after callbacks → check if after callbacks
+      contain cleanup logic that must run even when before halts.
+      This is deprecated in 7.0 anyway.
+      Most apps → safe to use new default.
+
+  - config: action_dispatch.cookies_same_site_protection
+    config_line: "Rails.application.config.action_dispatch.cookies_same_site_protection = :lax"
+    new_default: ":lax"
+    old_default: "nil (no SameSite attribute)"
+    risk: low
+    old_behavior: "Cookies do not include a SameSite attribute"
+    new_behavior: "Cookies include SameSite=Lax by default"
+    lookup:
+      - search: "cookies_same_site_protection\\|SameSite\\|same_site"
+        in: "config/**/*.rb, app/controllers/**/*.rb"
+        reason: "Check for existing SameSite configuration"
+      - search: "cookies\\["
+        in: "app/controllers/**/*.rb"
+        reason: "Check for cookie usage"
+    decision: >
+      If no custom SameSite config → safe to use new default (:lax). This is
+      the browser default behavior for modern browsers anyway.
+      If the app needs cross-site cookies (e.g., embedded iframes, OAuth) →
+      those specific cookies may need SameSite=None with Secure flag.
+      Most apps → safe to use new default.
+
+  - config: action_controller.urlsafe_csrf_tokens
+    config_line: "Rails.application.config.action_controller.urlsafe_csrf_tokens = true"
+    new_default: true
+    old_default: false
+    risk: low
+    old_behavior: "CSRF tokens use standard Base64 encoding"
+    new_behavior: "CSRF tokens use URL-safe Base64 encoding"
+    lookup:
+      - search: "csrf\\|authenticity_token"
+        in: "app/**/*.rb, app/views/**/*"
+        reason: "Check for custom CSRF token handling"
+    decision: >
+      If no custom CSRF token handling → safe to use new default (true).
+      Not backwards compatible with earlier Rails versions — enable only
+      after the app is fully stable on 6.1.
+      Most apps → safe to use new default.
+
+  - config: active_support.utc_to_local_returns_utc_offset_times
+    config_line: "ActiveSupport.utc_to_local_returns_utc_offset_times = true"
+    new_default: true
+    old_default: false
+    risk: low
+    old_behavior: "utc_to_local returns a time with UTC timezone"
+    new_behavior: "utc_to_local returns a time with the proper UTC offset"
+    lookup:
+      - search: "utc_to_local"
+        in: "app/**/*.rb, lib/**/*.rb"
+        reason: "Check for direct utc_to_local usage"
+    decision: >
+      If no utc_to_local usage → safe to use new default (true), zero impact.
+      If used → the new behavior is more correct. Check if any code depends
+      on the returned time having UTC timezone.
+      Most apps → safe to use new default.
+
+  - config: action_dispatch.ssl_default_redirect_status
+    config_line: "Rails.application.config.action_dispatch.ssl_default_redirect_status = 308"
+    new_default: 308
+    old_default: 301
+    risk: low
+    old_behavior: "Non-GET/HEAD requests to HTTP are redirected with 301 (may change method to GET)"
+    new_behavior: "Non-GET/HEAD requests are redirected with 308 (preserves HTTP method)"
+    lookup:
+      - search: "force_ssl\\|ssl_default_redirect_status"
+        in: "config/**/*.rb"
+        reason: "Check if force_ssl is used and if redirect status is customized"
+    decision: >
+      If force_ssl is not used → no impact, safe.
+      If force_ssl is used → 308 is more correct (preserves method). Safe for
+      modern browsers. Only concern is very old clients that don't support 308.
+      Most apps → safe to use new default.
+
+  - config: action_view.form_with_generates_remote_forms
+    config_line: "Rails.application.config.action_view.form_with_generates_remote_forms = false"
+    new_default: false
+    old_default: true
+    risk: low
+    old_behavior: "form_with generates remote (AJAX) forms by default"
+    new_behavior: "form_with generates standard (non-remote) forms by default"
+    lookup:
+      - search: "form_with"
+        in: "app/views/**/*.erb, app/views/**/*.haml, app/views/**/*.slim"
+        reason: "Find all form_with usages"
+      - search: "remote:"
+        in: "app/views/**/*.erb, app/views/**/*.haml, app/views/**/*.slim"
+        reason: "Check if forms specify remote: explicitly"
+    decision: >
+      If form_with is not used → safe to use new default (false), zero impact.
+      If form_with is used without explicit remote: → forms will become
+      non-remote. This is the more common and expected behavior.
+      If forms rely on being remote → add remote: true explicitly to those forms.
+      Most apps → safe to use new default.
+
+  - config: action_view.preload_links_header
+    config_line: "Rails.application.config.action_view.preload_links_header = true"
+    new_default: true
+    old_default: false
+    risk: low
+    old_behavior: "No Link header for asset preloading"
+    new_behavior: >
+      Generates a Link header for preloading assets when using
+      javascript_include_tag and stylesheet_link_tag. Hints modern browsers
+      to preload assets.
+    lookup:
+      - search: "javascript_include_tag\\|stylesheet_link_tag"
+        in: "app/views/layouts/**/*"
+        reason: "Check if these helpers are used"
+      - search: "preload_links_header"
+        in: "config/**/*.rb"
+        reason: "Check if already configured"
+    decision: >
+      If the app uses a CDN or custom asset serving → check that the Link
+      header doesn't cause issues with the CDN.
+      If standard Rails asset serving → safe to use new default (true).
+      Most apps → safe to use new default.
+
+tier_3_reference:
+  - config: active_record.legacy_connection_handling
+    config_line: "Rails.application.config.active_record.legacy_connection_handling = false"
+    new_default: false
+    old_default: true
+    risk: medium
+    note: >
+      Switches to the new connection handling API. For single-database apps,
+      this has no effect. For multi-database apps, this enables granular
+      connection swapping. Check if the app uses multiple databases and
+      test thoroughly.

--- a/templates/new_framework_defaults_5_0.rb
+++ b/templates/new_framework_defaults_5_0.rb
@@ -1,0 +1,38 @@
+# Be sure to restart your server when you modify this file.
+#
+# This file contains migration options to ease your Rails 5.0 upgrade.
+#
+# Once upgraded flip defaults one by one to migrate to the new default.
+#
+# Read the Guide for Upgrading Ruby on Rails for more info on each option.
+
+# Added as false during the upgrade, this allows running the tests in Rails 5.0
+# to find places where this needs to be changed. After all deprecations are
+# fixed this can be changed to true to avoid re-introducing the deprecated code.
+#
+# NOTE: this setting was deprecated in Rails 5.1 (since 5.1 it always behaves as true)
+# and then removed, remove when upgrading to 5.2
+#
+# When this value is false, it shows a deprecation in Rails 5.0 in the affected places.
+# This deprecation should be fixed in a 5.0 to 5.1 upgrade, then changed to true, and
+# then removed in a 5.1 to 5.2 upgrade.
+#
+# Because it was removed, This setting does not show up in the latest guides,
+# check https://guides.rubyonrails.org/v5.0/configuring.html for more details:
+Rails.application.config.action_controller.raise_on_unfiltered_parameters = false
+
+# Enable per-form CSRF tokens. Previous versions had false.
+Rails.application.config.action_controller.per_form_csrf_tokens = false
+
+# Enable origin-checking CSRF mitigation. Previous versions had false.
+Rails.application.config.action_controller.forgery_protection_origin_check = false
+
+# Make Ruby 2.4 preserve the timezone of the receiver when calling `to_time`.
+# Previous versions had false.
+ActiveSupport.to_time_preserves_timezone = false
+
+# Require `belongs_to` associations by default. Previous versions had false.
+Rails.application.config.active_record.belongs_to_required_by_default = false
+
+# Do not halt callback chains when a callback returns false. Previous versions had true.
+ActiveSupport.halt_callback_chains_on_return_false = true

--- a/templates/new_framework_defaults_5_1.rb
+++ b/templates/new_framework_defaults_5_1.rb
@@ -1,0 +1,21 @@
+# Be sure to restart your server when you modify this file.
+#
+# This file contains migration options to ease your Rails 5.1 upgrade.
+#
+# Once upgraded flip defaults one by one to migrate to the new default.
+#
+# Read the Guide for Upgrading Ruby on Rails for more info on each option.
+
+# Make `form_with` generate non-remote forms.
+#
+# Note: this value's default changes to true in Rails 5.1 but then it changes
+# back to false in Rails 6.1
+#
+# If this file is removed in favor of load_defaults we should recommend setting
+# the value they actually want to use in the future to prevent defaults from
+# changing it.
+Rails.application.config.action_view.form_with_generates_remote_forms = false
+
+# Unknown asset fallback will return the path passed in when the given
+# asset is not present in the asset pipeline.
+# Rails.application.config.assets.unknown_asset_fallback = false

--- a/templates/new_framework_defaults_5_2.rb
+++ b/templates/new_framework_defaults_5_2.rb
@@ -1,0 +1,44 @@
+# Be sure to restart your server when you modify this file.
+#
+# This file contains migration options to ease your Rails 5.2 upgrade.
+#
+# Once upgraded flip defaults one by one to migrate to the new default.
+#
+# Read the Guide for Upgrading Ruby on Rails for more info on each option.
+
+# Make Active Record use stable #cache_key alongside new #cache_version method.
+# This is needed for recyclable cache keys.
+# Rails.application.config.active_record.cache_versioning = true
+
+# Use AES-256-GCM authenticated encryption for encrypted cookies.
+# Also, embed cookie expiry in signed or encrypted cookies for increased security.
+#
+# This option is not backwards compatible with earlier Rails versions.
+# It's best enabled when your entire app is migrated and stable on 5.2.
+#
+# Existing cookies will be converted on read then written with the new scheme.
+# Rails.application.config.action_dispatch.use_authenticated_cookie_encryption = true
+
+# Use AES-256-GCM authenticated encryption as default cipher for encrypting messages
+# instead of AES-256-CBC, when use_authenticated_message_encryption is set to true.
+# Rails.application.config.active_support.use_authenticated_message_encryption = true
+
+# Add default protection from forgery to ActionController::Base instead of in
+# ApplicationController.
+# Rails.application.config.action_controller.default_protect_from_forgery = true
+
+# Store boolean values are in sqlite3 databases as 1 and 0 instead of 't' and
+# 'f' after migrating old data.
+# Rails.application.config.active_record.sqlite3.represent_boolean_as_integer = true
+
+# Use SHA-1 instead of MD5 to generate non-sensitive digests, such as the ETag header.
+#
+# Note: this value's default changes to true in Rails 5.1 but then it changes back to
+# false in Rails 6.1
+#
+# If this file is removed in favor of load_defaults we should recommend setting the
+# value they actually want to use in the future to prevent defaults from changing it:
+# Rails.application.config.active_support.use_sha1_digests = true
+
+# Make `form_with` generate id attributes for any generated HTML tags.
+# Rails.application.config.action_view.form_with_generates_ids = true

--- a/templates/new_framework_defaults_6_0.rb
+++ b/templates/new_framework_defaults_6_0.rb
@@ -1,0 +1,53 @@
+# Be sure to restart your server when you modify this file.
+#
+# This file contains migration options to ease your Rails 6.0 upgrade.
+#
+# Once upgraded flip defaults one by one to migrate to the new default.
+#
+# Read the Guide for Upgrading Ruby on Rails for more info on each option.
+
+# Don't force requests from old versions of IE to be UTF-8 encoded.
+# Rails.application.config.action_view.default_enforce_utf8 = false
+
+# Embed purpose and expiry metadata inside signed and encrypted
+# cookies for increased security.
+#
+# This option is not backwards compatible with earlier Rails versions.
+# It's best enabled when your entire app is migrated and stable on 6.0.
+# Rails.application.config.action_dispatch.use_cookies_with_metadata = true
+
+# Change the return value of `ActionDispatch::Response#content_type` to Content-Type header without modification.
+#
+# This setting is then deprecated in Rails 6.1 and removed in 7.0, the final behavior
+# is as if that setting is set to false (always returns full header when calling content-type):
+# Rails.application.config.action_dispatch.return_only_media_type_on_content_type = false
+
+# Return false instead of self when enqueuing is aborted from a callback.
+#
+# This setting is then deprecated in Rails 6.1 and removed in 7.0, the final behavior is as if
+# that setting is set to true (always returns false when enqueuing fails)
+# Rails.application.config.active_job.return_false_on_aborted_enqueue = true
+
+# Send Active Storage analysis and purge jobs to dedicated queues.
+#
+# These 2 are later replaced with nil in the 6.1 defaults:
+# Rails.application.config.active_storage.queues.analysis = :active_storage_analysis
+# Rails.application.config.active_storage.queues.purge    = :active_storage_purge
+
+# When assigning to a collection of attachments declared via `has_many_attached`, replace existing
+# attachments instead of appending. Use #attach to add new attachments without replacing existing ones.
+# Rails.application.config.active_storage.replace_on_assign_to_many = true
+
+# Use ActionMailer::MailDeliveryJob for sending parameterized and normal mail.
+#
+# The default delivery jobs (ActionMailer::Parameterized::DeliveryJob, ActionMailer::DeliveryJob),
+# will be removed in Rails 6.1. This setting is not backwards compatible with earlier Rails versions.
+# If you send mail in the background, job workers need to have a copy of
+# MailDeliveryJob to ensure all delivery jobs are processed properly.
+# Make sure your entire app is migrated and stable on 6.0 before using this setting.
+# Rails.application.config.action_mailer.delivery_job = "ActionMailer::MailDeliveryJob"
+
+# Enable the same cache key to be reused when the object being cached of type
+# `ActiveRecord::Relation` changes by moving the volatile information (max updated at and count)
+# of the relation's cache key into the cache version to support recycling cache key.
+# Rails.application.config.active_record.collection_cache_versioning = true

--- a/templates/new_framework_defaults_6_1.rb
+++ b/templates/new_framework_defaults_6_1.rb
@@ -1,0 +1,70 @@
+# Be sure to restart your server when you modify this file.
+#
+# This file contains migration options to ease your Rails 6.1 upgrade.
+#
+# Once upgraded flip defaults one by one to migrate to the new default.
+#
+# Read the Guide for Upgrading Ruby on Rails for more info on each option.
+
+# Support for inversing belongs_to -> has_many Active Record associations.
+# Rails.application.config.active_record.has_many_inversing = true
+
+# Track Active Storage variants in the database.
+# Rails.application.config.active_storage.track_variants = true
+
+# Apply random variation to the delay when retrying failed jobs.
+# Rails.application.config.active_job.retry_jitter = 0.15
+
+# Stop executing `after_enqueue`/`after_perform` callbacks if
+# `before_enqueue`/`before_perform` respectively halts with `throw :abort`.
+#
+# Deprecated in 7.0, final behavior is always as if it is set to true
+# (does not execute after callbacks after halt)
+# Rails.application.config.active_job.skip_after_callbacks_if_terminated = true
+
+# Specify cookies SameSite protection level: either :none, :lax, or :strict.
+#
+# This change is not backwards compatible with earlier Rails versions.
+# It's best enabled when your entire app is migrated and stable on 6.1.
+# Rails.application.config.action_dispatch.cookies_same_site_protection = :lax
+
+# Generate CSRF tokens that are encoded in URL-safe Base64.
+#
+# This change is not backwards compatible with earlier Rails versions.
+# It's best enabled when your entire app is migrated and stable on 6.1.
+# Rails.application.config.action_controller.urlsafe_csrf_tokens = true
+
+# Specify whether `ActiveSupport::TimeZone.utc_to_local` returns a time with an
+# UTC offset or a UTC time.
+# ActiveSupport.utc_to_local_returns_utc_offset_times = true
+
+# Change the default HTTP status code to `308` when redirecting non-GET/HEAD
+# requests to HTTPS in `ActionDispatch::SSL` middleware.
+# Rails.application.config.action_dispatch.ssl_default_redirect_status = 308
+
+# Use new connection handling API. For most applications this won't have any
+# effect. For applications using multiple databases, this new API provides
+# support for granular connection swapping.
+# Rails.application.config.active_record.legacy_connection_handling = false
+
+# Make `form_with` generate non-remote forms by default.
+# Rails.application.config.action_view.form_with_generates_remote_forms = false
+
+# Set the default queue name for the analysis job to the queue adapter default.
+# Rails.application.config.active_storage.queues.analysis = nil
+
+# Set the default queue name for the purge job to the queue adapter default.
+# Rails.application.config.active_storage.queues.purge = nil
+
+# Set the default queue name for the incineration job to the queue adapter default.
+# Rails.application.config.action_mailbox.queues.incineration = nil
+
+# Set the default queue name for the routing job to the queue adapter default.
+# Rails.application.config.action_mailbox.queues.routing = nil
+
+# Set the default queue name for the mail deliver job to the queue adapter default.
+# Rails.application.config.action_mailer.deliver_later_queue_name = nil
+
+# Generate a `Link` header that gives a hint to modern browsers about
+# preloading assets when using `javascript_include_tag` and `stylesheet_link_tag`.
+# Rails.application.config.action_view.preload_links_header = true

--- a/templates/new_framework_defaults_6_1.rb
+++ b/templates/new_framework_defaults_6_1.rb
@@ -62,7 +62,7 @@
 # Set the default queue name for the routing job to the queue adapter default.
 # Rails.application.config.action_mailbox.queues.routing = nil
 
-# Set the default queue name for the mail deliver job to the queue adapter default.
+# Set the default queue name for the mail delivery job to the queue adapter default.
 # Rails.application.config.action_mailer.deliver_later_queue_name = nil
 
 # Generate a `Link` header that gives a hint to modern browsers about


### PR DESCRIPTION
## Summary
- Adds config YAML files and initializer templates for Rails 5.0, 5.1, 5.2, 6.0, and 6.1 framework defaults
- Each version includes tiered risk assessment, codebase lookup patterns, and decision trees following the same structure as the existing 7.0+ configs
- Updates SKILL.md and README.md to reference all supported versions (5.0 through 7.2)

Closes #1

## Test plan
- [ ] Verify each config YAML file parses correctly
- [ ] Verify each template file matches the canonical Rails initializer content
- [ ] Test the skill against a Rails app with `load_defaults` set to a pre-5.0 or 5.x version

🤖 Generated with [Claude Code](https://claude.com/claude-code)