### PR TITLE
Add Claude Code plugin manifest

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "rails-load-defaults",
+  "version": "1.0.0",
+  "description": "Align Rails load_defaults across versions with safe, incremental config changes based on FastRuby.io methodology",
+  "skills": "./rails-load-defaults/",
+  "author": {
+    "name": "OmbuLabs",
+    "url": "https://github.com/ombulabs"
+  },
+  "repository": "https://github.com/ombulabs/claude-code_rails-load-defaults-skill",
+  "license": "MIT",
+  "keywords": ["rails", "configuration", "upgrade", "load_defaults"]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -9,5 +9,18 @@
   },
   "repository": "https://github.com/ombulabs/claude-code_rails-load-defaults-skill",
   "license": "MIT",
-  "keywords": ["ruby", "rails", "upgrade", "migration", "fastruby", "breaking-changes", "tech-debt", "deprecations", "legacy-code", "ruby-on-rails", "configuration", "load_defaults"]
+  "keywords": [
+    "ruby",
+    "rails",
+    "upgrade",
+    "migration",
+    "fastruby",
+    "breaking-changes",
+    "tech-debt",
+    "deprecations",
+    "legacy-code",
+    "ruby-on-rails",
+    "configuration",
+    "load_defaults"
+  ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -9,5 +9,5 @@
   },
   "repository": "https://github.com/ombulabs/claude-code_rails-load-defaults-skill",
   "license": "MIT",
-  "keywords": ["rails", "configuration", "upgrade", "load_defaults"]
+  "keywords": ["ruby", "rails", "upgrade", "migration", "fastruby", "breaking-changes", "tech-debt", "deprecations", "legacy-code", "ruby-on-rails", "configuration", "load_defaults"]
 }

--- a/README.md
+++ b/README.md
@@ -14,11 +14,18 @@ This skill automates the process of bringing a Rails app's `load_defaults` confi
 
 ## Installation
 
-From your Rails project directory, run:
+**Via the OmbuLabs marketplace (recommended):**
 
 ```bash
-mkdir -p ~/.claude/skills
-git clone https://github.com/fastruby/rails-load-defaults-skill.git ~/.claude/skills/rails-load-defaults-skill
+claude plugin marketplace add https://github.com/ombulabs/claude-skills.git
+claude plugin install rails-load-defaults@ombulabs-skills
+```
+
+**Manual install:**
+
+```bash
+git clone https://github.com/ombulabs/claude-code_rails-load-defaults-skill.git
+cp -r claude-code_rails-load-defaults-skill/rails-load-defaults ~/.claude/skills/
 ```
 
 Installing to `~/.claude/skills/` makes it available across all your projects.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This skill automates the process of bringing a Rails app's `load_defaults` confi
 
 ```bash
 claude plugin marketplace add https://github.com/ombulabs/claude-skills.git
-claude plugin install rails-load-defaults@ombulabs-skills
+claude plugin install rails-load-defaults@ombulabs-ai
 ```
 
 **Manual install:**

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ cp -r claude-code_rails-load-defaults-skill/rails-load-defaults ~/.claude/skills
 
 Installing to `~/.claude/skills/` makes it available across all your projects.
 
+> [!NOTE]
+> This skill works standalone, but it is part of the full Rails upgrade toolkit. You may also want to install [dual-boot](https://github.com/ombulabs/claude-code_dual-boot-skill) and [rails-upgrade](https://github.com/ombulabs/claude-code_rails-upgrade-skill).
+
 ## Usage
 
 Once installed, invoke the skill with:


### PR DESCRIPTION
## Summary

- Adds `.claude-plugin/plugin.json` so this repo can be installed as a Claude Code plugin
- Uses the `skills` field to point to the existing `rails-load-defaults/` directory, no file restructuring needed
- Part of the OmbuLabs skills marketplace setup (ombulabs/claude-skills)

## Context

We are setting up an OmbuLabs marketplace (`ombulabs/claude-skills`) that will reference this repo via git URL. This manifest is required for Claude Code to recognize the repo as a plugin.

## Test plan

- [ ] Install locally with `claude --plugin-dir ./` and verify `/rails-load-defaults:rails-load-defaults` is available
- [ ] Confirm SKILL.md is loaded correctly when the skill is invoked